### PR TITLE
FIX: Message Author Comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ client.on("message", (msg) => {
 		return;
 	}
 
-	if (msg.author.id === KristenUserId) {
+	// Discord.js returns a string we need to convert to a Number
+	const msgAuthorId = Number(msg.author.id);
+
+	if (msgAuthorId === KristenUserId) {
 		lastKristen = Date.now();
 	}
 
@@ -47,7 +50,7 @@ client.on("message", (msg) => {
 	}
 
 	if (c.includes("good") && c.includes("morning")) {
-		if (msg.author.id === KristenUserId) {
+		if (msgAuthorId === KristenUserId) {
 			msg.channel.send(randomString(responses.goodMorningK));
 		} else {
 			msg.channel.send(randomString(responses.goodMorning, msg.author.username));
@@ -57,7 +60,7 @@ client.on("message", (msg) => {
 	}
 
 	if (c.includes("good") && c.includes("night")) {
-		if (msg.author.id === KristenUserId) {
+		if (msgAuthorId === KristenUserId) {
 			msg.channel.send(randomString(responses.goodNightK));
 		} else {
 			msg.channel.send(randomString(responses.goodNight));
@@ -67,7 +70,7 @@ client.on("message", (msg) => {
 	}
 
 	if (c.includes("good") && c.includes("afternoon")) {
-		if (msg.author.id === KristenUserId) {
+		if (msgAuthorId === KristenUserId) {
 			msg.channel.send(randomString(responses.goodAfternoonListK));
 		} else {
 			msg.channel.send(randomString(responses.goodAfternoonList));
@@ -76,7 +79,7 @@ client.on("message", (msg) => {
 		return;
 	}
 	if (c.includes("good") && c.includes("evening")) {
-		if (msg.author.id === KristenUserId) {
+		if (msgAuthorId === KristenUserId) {
 			msg.channel.send(randomString(responses.goodEveningListK));
 		} else {
 			msg.channel.send(randomString(responses.goodEveningList));
@@ -93,7 +96,7 @@ client.on("message", (msg) => {
 	if (
 		(c.includes("friends") || c.includes("friend")) &&
 		(c.includes("message") || c.includes("messages")) &&
-		msg.author.id === KristenUserId
+		msgAuthorId === KristenUserId
 	) {
 		msg.channel.send(randomString(responses.freindMessages));
 		return;
@@ -105,7 +108,7 @@ client.on("message", (msg) => {
 		if (timeSinceKristen > twoHours) {
 			msg.channel.send(randomString(responses.missKristen));
 		} else {
-			if (msg.author.id === KristenUserId) {
+			if (msgAuthorId === KristenUserId) {
 				msg.channel.send(randomString(responses.doingOkK));
 			} else {
 				msg.channel.send(randomString(responses.doingOk));
@@ -118,7 +121,7 @@ client.on("message", (msg) => {
 		c.includes("love") &&
 		c.includes("you") &&
 		c.includes(client.user.username) &&
-		msg.author.id === KristenUserId
+		msgAuthorId === KristenUserId
 	) {
 		msg.channel.send(randomString(responses.iLoveYouToo));
 		return;


### PR DESCRIPTION
Discord.js returns a String when calling msg.author.id and the variable
KristenUserId was a Number. Converting msg.author.id to a Number works
on all platforms while String comparison in javascript failed in our
testing.

Thanks to @jromovel for discovering the bug and @matsprehn for debugging a coming up with a solution.

Signed-off-by: Adam Brenner <adam@aeb.io>